### PR TITLE
Updated the contributing documentation to reflect the new location of…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,23 +6,23 @@ If you are reading this document then you are interested in contributing to the 
 
 For the time being, the community around this project is centred at the [Islandora Foundation, Fedora 4 Interest Group](https://github.com/Islandora/Islandora-Fedora4-Interest-Group). The group meets on the fourth Friday of each month at 1PM EST. The meetings usually happen via Skype, and meeting announcements/agendas are posted to the [Islandora community list](https://groups.google.com/forum/#!forum/islandora) and the [Islandora developers list](https://groups.google.com/forum/#!forum/islandora-dev). You can view meeting agendas and minutes [here](https://github.com/islandora-interest-groups/Islandora-Fedora4-Interest-Group/tree/master/meetings).
 
-There is an additional 7.x-2.x Tech Call that occurs each Wednesday at 1:00pm Eastern Daylight Time US (UTC-4). Agendas with call-in details can be found [here](https://github.com/Islandora-Labs/islandora/wiki#islandora-7x-2x-tech-calls).
+There is an additional 7.x-2.x Tech Call that occurs each Wednesday at 1:00pm Eastern Daylight Time US (UTC-4). Agendas with call-in details can be found [here](https://github.com/Islandora-CLAW/CLAW/wiki#islandora-7x-2x-tech-calls).
 
 ### Use cases
 
-If you would like to submit a use case for the Chullo project, please submit and issue [here](https://github.com/Islandora-Labs/Chullo/issues) using the [Use Case template](https://github.com/Islandora/Islandora-Fedora4-Interest-Group/wiki/Use-Case-template), assign the "use case" label to the issue.
+If you would like to submit a use case for the Chullo project, please submit and issue [here](https://github.com/Islandora-CLAW/Chullo/issues) using the [Use Case template](https://github.com/Islandora/Islandora-Fedora4-Interest-Group/wiki/Use-Case-template), assign the "use case" label to the issue.
 
 ### Documentation
 
-You can contribute documentation in two different ways. One way is to create an issue [here](https://github.com/Islandora-Labs/Chullo/issues) assign the "documentation" label to the issue. Another way is to by pull request, as same as code contribution.
+You can contribute documentation in two different ways. One way is to create an issue [here](https://github.com/Islandora-CLAW/Chullo/issues) assign the "documentation" label to the issue. Another way is to by pull request, as same as code contribution.
 
 ### Request a new feature
 
-To request a new feature you should [open an issue or use case](https://github.com/Islandora-Labs/Chullo/issues) (see _use case_ section above), and summarize the desired functionality. Select the label "enhancement" if creating an issue on the project repo, and "use case" if creating a use case.
+To request a new feature you should [open an issue or use case](https://github.com/Islandora-CLAW/Chullo/issues) (see _use case_ section above), and summarize the desired functionality. Select the label "enhancement" if creating an issue on the project repo, and "use case" if creating a use case.
 
 ### Report a bug
 
-To report a bug you should [open an issue](https://github.com/Islandora-Labs/Chullo/issues) that summarizes the bug. Set the label to "bug".
+To report a bug you should [open an issue](https://github.com/Islandora-CLAW/Chullo/issues) that summarizes the bug. Set the label to "bug".
 
 In order to help us understand and fix the bug it would be great if you could provide us with:
 
@@ -42,14 +42,14 @@ Before you set out to contribute code you will need to have completed a [Contrib
 
 _If you are interested in contributing code to Islandora but do not know where to begin:_
 
-In this case you should [browse open issues and use cases](https://github.com/Islandora-Labs/Chullo/issues).
+In this case you should [browse open issues and use cases](https://github.com/Islandora-CLAW/Chullo/issues).
 
 Contributions to the Islandora codebase should be sent as GitHub pull requests. See section _Create a pull request_ below for details. If there is any problem with the pull request we can work through it using the commenting features of GitHub.
 
 * For _small patches_, feel free to submit pull requests directly for those patches.
 * For _larger code contributions_, please use the following process. The idea behind this process is to prevent any wasted work and catch design issues early on.
 
-    1. [Open an issue](https://github.com/Islandora-Labs/islandora/issues) and assign it the label of "enhancement", if a similar issue does not exist already. If a similar issue does exist, then you may consider participating in the work on the existing issue.
+    1. [Open an issue](https://github.com/Islandora-CLAW/Chullo/issues) and assign it the label of "enhancement", if a similar issue does not exist already. If a similar issue does exist, then you may consider participating in the work on the existing issue.
     2. Comment on the issue with your plan for implementing the issue. Explain what pieces of the codebase you are going to touch and how everything is going to fit together.
     3. Islandora committers will work with you on the design to make sure you are on the right track.
     4. Implement your issue, create a pull request (see below), and iterate from there.
@@ -59,9 +59,9 @@ Contributions to the Islandora codebase should be sent as GitHub pull requests. 
 Take a look at [Creating a pull request](https://help.github.com/articles/creating-a-pull-request).  In a nutshell you
 need to:
 
-1. [Fork](https://help.github.com/articles/fork-a-repo) the Islandora GitHub repository at [https://github.com/islandora-labs/chullo](https://github.com/islandora-labs/chullo) to your personal GitHub account.  See [Fork a repo](https://help.github.com/articles/fork-a-repo) for detailed instructions.
+1. [Fork](https://help.github.com/articles/fork-a-repo) the Islandora GitHub repository at [https://github.com/Islandora-CLAW/chullo](https://github.com/Islandora-CLAW/chullo) to your personal GitHub account.  See [Fork a repo](https://help.github.com/articles/fork-a-repo) for detailed instructions.
 2. Commit any changes to your fork.
-3. Send a [pull request](https://help.github.com/articles/creating-a-pull-request) to the Islandora GitHub repository that you forked in step 1.  If your pull request is related to an existing Islandora issue -- for instance, because you reported a bug/issue earlier -- then prefix the title of your pull request with the corresponding issue number (e.g. `ISLANDORA-123: ...`).
+3. Send a [pull request](https://help.github.com/articles/creating-a-pull-request) to the Islandora GitHub repository that you forked in step 1.  If your pull request is related to an existing issue -- for instance, because you reported a [bug/issue](https://github.com/Islandora-CLAW/Chullo/issues) earlier -- then please include a reference to the issue in the description of the pull. This can be done by using '#' plus the issue number like so '#123', also try to pick and appropriate name for the branch in which your issuing the pull request from. 
 
 You may want to read [Syncing a fork](https://help.github.com/articles/syncing-a-fork) for instructions on how to keep your fork up to date with the latest changes of the upstream (official) `islandora` repository.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ need to:
 
 1. [Fork](https://help.github.com/articles/fork-a-repo) the Islandora GitHub repository at [https://github.com/Islandora-CLAW/chullo](https://github.com/Islandora-CLAW/chullo) to your personal GitHub account.  See [Fork a repo](https://help.github.com/articles/fork-a-repo) for detailed instructions.
 2. Commit any changes to your fork.
-3. Send a [pull request](https://help.github.com/articles/creating-a-pull-request) to the Islandora GitHub repository that you forked in step 1.  If your pull request is related to an existing issue -- for instance, because you reported a [bug/issue](https://github.com/Islandora-CLAW/Chullo/issues) earlier -- then please include a reference to the issue in the description of the pull. This can be done by using '#' plus the issue number like so '#123', also try to pick and appropriate name for the branch in which your issuing the pull request from. 
+3. Send a [pull request](https://help.github.com/articles/creating-a-pull-request) to the Islandora GitHub repository that you forked in step 1.  If your pull request is related to an existing issue -- for instance, because you reported a [bug/issue](https://github.com/Islandora-CLAW/Chullo/issues) earlier -- prefix the title of your pull request with the corresponding issue number (e.g. `issue-123: ...`). Please also include a reference to the issue in the description of the pull. This can be done by using '#' plus the issue number like so '#123', also try to pick an appropriate name for the branch in which you're issuing the pull request from. 
 
 You may want to read [Syncing a fork](https://help.github.com/articles/syncing-a-fork) for instructions on how to keep your fork up to date with the latest changes of the upstream (official) `islandora` repository.
 


### PR DESCRIPTION
… the

repository, also updated the documentation to reflect the current practice of
using Github Issues rather than JIRA.

To address Islandora-CLAW/CLAW/issues/114, this is also related to Islandora-CLAW/CLAW/pull/115