### PR TITLE
Make some composer version "requires" more flexible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     "require": {
         "php": ">=5.5.0",
         "guzzlehttp/guzzle": "6.1.0",
-        "easyrdf/easyrdf": "0.9.0",
-        "ml/json-ld":   "1.0.3"
+        "easyrdf/easyrdf": "^0.9",
+        "ml/json-ld":   "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
     },
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "6.1.0",
-        "easyrdf/easyrdf": "^0.9",
-        "ml/json-ld":   "^1.0"
+        "guzzlehttp/guzzle": "^6.1.0",
+        "easyrdf/easyrdf": "^0.9.1",
+        "ml/json-ld": "^1.0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"


### PR DESCRIPTION
# What does this pull do?

Resolves Issue #34 , related to #33 making cross development with some Silex dependant packages simpler by allowing, further know good versions of some packages inside the same non-breaking, to be updated.

# How to test?
run  `composer update` you will see some packages get updates
if you do the same on depending islandora-claw services, it will work also.