### PR TITLE
Headers passthru

### DIFF
--- a/src/Chullo.php
+++ b/src/Chullo.php
@@ -216,8 +216,8 @@ class Chullo implements IFedoraClient
         $checksum_value = sha1($turtle);
 
         // Set headers.
-        $headers['Content-Type' => 'text/turtle'];
-        $headers['digest' => 'sha1='.$checksum_value];
+        $headers['Content-Type'] = 'text/turtle';
+        $headers['digest'] = 'sha1=' . $checksum_value;
 
         // Save it.
         return $this->saveResource(
@@ -259,7 +259,7 @@ class Chullo implements IFedoraClient
      * @return boolean  True if successful
      */
     public function deleteResource(
-        $uri,
+        $uri = '',
         $headers = []
     ) {
         $response = $this->api->deleteResource(

--- a/src/Chullo.php
+++ b/src/Chullo.php
@@ -80,14 +80,17 @@ class Chullo implements IFedoraClient
      * Gets a Fedora resource's headers.
      *
      * @param string    $uri            Resource URI
+     * @param array     $headers        HTTP Headers
      *
      * @return array    Headers of a resource, null on failure
      */
     public function getResourceHeaders(
-        $uri = ""
+        $uri = "",
+        $headers = []
     ) {
         $response = $this->api->getResourceHeaders(
-            $uri
+            $uri,
+            $headers
         );
 
         if ($response->getStatusCode() != 200) {
@@ -101,13 +104,17 @@ class Chullo implements IFedoraClient
      * Gets information about the supported HTTP methods, etc., for a Fedora resource.
      *
      * @param string    $uri            Resource URI
+     * @param array     $headers        HTTP Headers
      *
      * @return string   Options of a resource.
      */
-    public function getResourceOptions($uri = "")
-    {
+    public function getResourceOptions(
+        $uri = "",
+        $headers = []
+    ) {
         $response = $this->api->getResourceOptions(
-            $uri
+            $uri,
+            $headers
         );
 
         return $response->getHeaders();
@@ -193,12 +200,14 @@ class Chullo implements IFedoraClient
      *
      * @param string            $uri            Resource URI
      * @param EasyRdf_Resource  $graph          Graph to save
+     * @param array             $headers        HTTP Headers
      *
      * @return boolean  True if successful
      */
     public function saveGraph(
         $uri,
-        \EasyRdf_Graph $graph
+        \EasyRdf_Graph $graph,
+        $headers = []
     ) {
         // Serialze the rdf.
         $turtle = $graph->serialise('turtle');
@@ -206,14 +215,15 @@ class Chullo implements IFedoraClient
         // Checksum it.
         $checksum_value = sha1($turtle);
 
+        // Set headers.
+        $headers['Content-Type' => 'text/turtle'];
+        $headers['digest' => 'sha1='.$checksum_value];
+
         // Save it.
         return $this->saveResource(
             $uri,
             $turtle,
-            [
-              'Content-Type' => 'text/turtle',
-              'digest' => 'sha1='.$checksum_value
-            ]
+            $headers
         );
     }
 
@@ -244,14 +254,17 @@ class Chullo implements IFedoraClient
      * Issues a DELETE request to Fedora.
      *
      * @param string    $uri            Resource URI
+     * @param array     $headers        HTTP Headers
      *
      * @return boolean  True if successful
      */
     public function deleteResource(
-        $uri
+        $uri,
+        $headers = []
     ) {
         $response = $this->api->deleteResource(
-            $uri
+            $uri,
+            $headers
         );
 
         return $response->getStatusCode() == 204;

--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -86,18 +86,20 @@ class FedoraApi implements IFedoraApi
      * Gets a Fedora resoure's headers.
      *
      * @param string    $uri            Resource URI
+     * @param array     $headers        HTTP Headers
      *
      * @return ResponseInterface
      */
     public function getResourceHeaders(
-        $uri = ""
+        $uri = "",
+        $headers = []
     ) {
 
         // Send the request.
         return $this->client->request(
             'HEAD',
             $uri,
-            ['http_errors' => false]
+            ['http_errors' => false, 'headers' => $headers]
         );
     }
 
@@ -105,15 +107,18 @@ class FedoraApi implements IFedoraApi
      * Gets information about the supported HTTP methods, etc., for a Fedora resource.
      *
      * @param string    $uri            Resource URI
+     * @param array     $headers        HTTP Headers
      *
      * @return ResponseInterface
      */
-    public function getResourceOptions($uri = "")
-    {
+    public function getResourceOptions(
+        $uri = "",
+        $headers = []
+    ) {
         return $this->client->request(
             'OPTIONS',
             $uri,
-            ['http_errors' => false]
+            ['http_errors' => false, 'headers' => $headers]
         );
     }
 
@@ -138,7 +143,7 @@ class FedoraApi implements IFedoraApi
 
         // Set headers.
         $options['headers'] = $headers;
-        
+
         return $this->client->request(
             'POST',
             $uri,
@@ -209,13 +214,15 @@ class FedoraApi implements IFedoraApi
      * Issues a DELETE request to Fedora.
      *
      * @param string    $uri            Resource URI
+     * @param array     $headers        HTTP Headers
      *
      * @return ResponseInterface
      */
     public function deleteResource(
-        $uri
+        $uri,
+        $headers = []
     ) {
-        $options = ['http_errors' => false];
+        $options = ['http_errors' => false, 'headers' => $headers];
 
         return $this->client->request(
             'DELETE',

--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -45,7 +45,9 @@ class FedoraApi implements IFedoraApi
      */
     public static function create($fedora_rest_url)
     {
-        $guzzle = new Client(['base_uri' => $fedora_rest_url]);
+        $normalized = rtrim($fedora_rest_url);
+        $normalized = rtrim($normalized, '/') . '/';
+        $guzzle = new Client(['base_uri' => $normalized]);
         return new static($guzzle);
     }
 
@@ -219,7 +221,7 @@ class FedoraApi implements IFedoraApi
      * @return ResponseInterface
      */
     public function deleteResource(
-        $uri,
+        $uri = '',
         $headers = []
     ) {
         $options = ['http_errors' => false, 'headers' => $headers];

--- a/src/IFedoraApi.php
+++ b/src/IFedoraApi.php
@@ -23,7 +23,7 @@ use Psr\Http\Message\ResponseInterface;
 
 /**
  * Interface for Fedora interaction.  All functions return a PSR-7 response.
-  */
+ */
 interface IFedoraApi
 {
     /**
@@ -43,20 +43,28 @@ interface IFedoraApi
         $uri = "",
         $headers = []
     );
+
     /**
      * Gets a Fedora resoure's headers.
      *
      * @param string    $uri            Resource URI
+     * @param array     $headers        HTTP Headers
      */
     public function getResourceHeaders(
-        $uri = ""
+        $uri = "",
+        $headers = []
     );
+
     /**
      * Gets information about the supported HTTP methods, etc., for a Fedora resource.
      *
      * @param string    $uri            Resource URI
+     * @param array     $headers        HTTP Headers
      */
-    public function getResourceOptions($uri = "");
+    public function getResourceOptions(
+        $uri = "",
+        $headers = []
+    );
 
     /**
      * Creates a new resource in Fedora.
@@ -101,8 +109,10 @@ interface IFedoraApi
      * Issues a DELETE request to Fedora.
      *
      * @param string    $uri            Resource URI
+     * @param array     $headers        HTTP Headers
      */
     public function deleteResource(
-        $uri
+        $uri = "",
+        $headers = []
     );
 }

--- a/src/IFedoraClient.php
+++ b/src/IFedoraClient.php
@@ -42,11 +42,13 @@ interface IFedoraClient extends IFedoraApi
      *
      * @param string            $uri            Resource URI
      * @param EasyRdf_Resource  $rdf            RDF to save
+     * @param array     $headers        HTTP Headers
      *
      * @return null
      */
     public function saveGraph(
         $uri,
-        \EasyRdf_Graph $graph
+        \EasyRdf_Graph $graph,
+        $headers = []
     );
 }


### PR DESCRIPTION
**GitHub Issue**: part of https://github.com/Islandora-CLAW/CLAW/issues/597

# What does this Pull Request do?

Adds parameters to functions in IFedoraApi and its implementations so that we can pass authorization tokens through to Fedora.  I ran into this when trying to issue a HEAD request to get an ETag.

# What's new?
The interface changes above.  I also ran into a funky issue with how Guzzle clients handle their base uri, so I added some sanitization around that so no one else wastes an hour next time they don't add the trailing slash to their fedora base url.

# How should this be tested?

Before this PR, give Chullo a base url of `http://localhost:8080/fcrepo/rest` and issue a PUT request to `http://localhost:8080/fcrepo/rest/foo`.  You should get denied with a 403.

Pull in this PR and do the same.  You should get a successful response and be able to visit the created resource.

You can then also issue HEAD, OPTION, and DELETE requests passing in your JWT as the 'Authorization' header with a FedoraApi class.  Analogous functions in Chullo have also been updated, so you can try those out too.

# Interested parties
@Islandora-CLAW/committers