### PR TITLE
Clean up composer configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,7 @@ install:
 
 script:
   - $SCRIPT_DIR/line_endings.sh $TRAVIS_BUILD_DIR
-  - vendor/bin/phpcs --standard=PSR2 src
-  - vendor/bin/phpcpd --names *.php src
-
-script:
-  - php vendor/bin/phpunit 
-  - php vendor/bin/phpcs --standard=PSR2 src test
-  - php vendor/bin/phpunit --verbose
+  - composer test
 
 notifications:
   irc:

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,20 @@
         "ml/json-ld": "^1.0.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
-        "squizlabs/php_codesniffer": "^2.0@dev",
+        "phpunit/phpunit": "^5.0",
+        "squizlabs/php_codesniffer": "^2.0",
+        "sebastian/phpcpd": "^3.0",
         "mockery/mockery": "^0.9"
+    },
+    "scripts": {
+        "check": [
+            "phpcs --standard=PSR2 src test",
+            "phpcpd --names *.php src test"
+        ],
+        "test": [
+            "@check",
+            "phpunit"
+        ]
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Add scripts section with test and check scripts.
Remove redundant travis configuration
Add `phpcpd` to the -dev dependencies

See similar PR at: Islandora-CLAW/Crayfish#25

# What does this Pull Request do?

This does not change any code. It only changes the Composer and Travis-CI configurations, making it easier to test code. This also removes some redundant configuration in `.travis.yml`.

# What's new?

 There are two noteworthy changes to `composer.json` beyond the addition of the `test` and `check` scripts, namely the addition of a `-dev` dependency on phpcpd (which travis is expecting anyway) and it aligns the versions of `phpunit` and `php_codesniffer` to the versions defined in the `Crayfish*` repositories.

# How should this be tested?

In the root of this repository, run `composer test`.

# Additional Notes:

See here for more information: https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands

# Interested parties
@Islandora-CLAW/committers