### PR TITLE
Add PHPDoc return types to src/IFedoraApi.php

### DIFF
--- a/src/IFedoraApi.php
+++ b/src/IFedoraApi.php
@@ -36,6 +36,7 @@ interface IFedoraApi
      *
      * @param string    $uri            Resource URI
      * @param array     $headers        HTTP Headers
+     * @return \Psr\Http\Message\ResponseInterface
      */
     public function getResource(
         $uri = "",
@@ -47,6 +48,7 @@ interface IFedoraApi
      *
      * @param string    $uri            Resource URI
      * @param array     $headers        HTTP Headers
+     * @return \Psr\Http\Message\ResponseInterface
      */
     public function getResourceHeaders(
         $uri = "",
@@ -58,6 +60,7 @@ interface IFedoraApi
      *
      * @param string    $uri            Resource URI
      * @param array     $headers        HTTP Headers
+     * @return \Psr\Http\Message\ResponseInterface
      */
     public function getResourceOptions(
         $uri = "",
@@ -70,6 +73,7 @@ interface IFedoraApi
      * @param string    $uri                  Resource URI
      * @param string    $content              String or binary content
      * @param array     $headers              HTTP Headers
+     * @return \Psr\Http\Message\ResponseInterface
      */
     public function createResource(
         $uri = "",
@@ -83,6 +87,7 @@ interface IFedoraApi
      * @param string    $uri                  Resource URI
      * @param string    $content              String or binary content
      * @param array     $headers              HTTP Headers
+     * @return \Psr\Http\Message\ResponseInterface
      */
     public function saveResource(
         $uri,
@@ -96,6 +101,7 @@ interface IFedoraApi
      * @param string    $uri            Resource URI
      * @param string    $sparql         SPARQL Update query
      * @param array     $headers        HTTP Headers
+     * @return \Psr\Http\Message\ResponseInterface
      */
     public function modifyResource(
         $uri,
@@ -108,6 +114,7 @@ interface IFedoraApi
      *
      * @param string    $uri            Resource URI
      * @param array     $headers        HTTP Headers
+     * @return \Psr\Http\Message\ResponseInterface
      */
     public function deleteResource(
         $uri = "",
@@ -120,6 +127,7 @@ interface IFedoraApi
      * @param EasyRdf_Resource  $rdf            Graph to save
      * @param string            $uri            Resource URI
      * @param array             $headers        HTTP Headers
+     * @return \Psr\Http\Message\ResponseInterface
      */
     public function saveGraph(
         \EasyRdf_Graph $graph,


### PR DESCRIPTION
**GitHub Issue**: [CLAW Issue 683](https://github.com/Islandora-CLAW/CLAW/issues/683)

Add return types to PHPDoc comments for Chullo #683
https://github.com/Islandora-CLAW/CLAW/issues/683

# What does this Pull Request do?

Allows (some) IDE's to provide type hints to developers when working on file src/IFedoraApi.php

# What's new?

I added PHPDoc return types of "\Psr\Http\Message\ResponseInterface" to the following functions in file src/IFedoraApi.php:

    public function getResource(…)
    public function getResourceHeaders(…)
    public function getResourceOptions(…)
    public function createResource(…)
    public function saveResource(…)
    public function modifyResource(…)
    public function deleteResource(…)
    public function saveGraph(…)

# How should this be tested?

* Open up file src/IFedoraApi.php in an IDE that understands PHPDoc
* Check if type hints are provided that mention a return type of "\Psr\Http\Message\ResponseInterface" for updated functions

# Interested parties
@Islandora-CLAW/committers