### PR TITLE
Versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
 branches:
   only:
     - /master/
+    - /^dev/
 
 before_install:
   - export SCRIPT_DIR=$HOME/CLAW/.scripts

--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -305,4 +305,24 @@ class FedoraApi implements IFedoraApi
         }
         return $graph;
     }
+
+    /**
+     * Creates version in Fedora.
+     * @param string $uri Resource Versions URI
+     * @param array $header HTTP Headers
+     *
+     * @return ResponseInterface
+     */
+    public function createVersion(
+        $uri = '',
+        $headers = []
+    ) {
+        $options = ['http_errors' => false, 'headers' => $headers];
+
+        return $this->client->request(
+            'POST',
+            $uri,
+            $options
+        );
+    }
 }

--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -378,8 +378,8 @@ class FedoraApi implements IFedoraApi
         $timemap_index = array_search('timemap', array_column($parsed_link_headers, 'rel'));
         if (is_int($timemap_index)) {
             $timemap_uri = $parsed_link_headers[$timemap_index][0];
+            $timemap_uri = trim($timemap_uri, "<> \t\n\r\0\x0B");
         }
-        $timemap_uri = trim($timemap_uri, "<> \t\n\r\0\x0B");
         return $timemap_uri;
     }
 }

--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -373,13 +373,11 @@ class FedoraApi implements IFedoraApi
         $resource_headers = $this->getResourceHeaders($uri, $headers);
         $parsed_link_headers = Psr7\parse_header($resource_headers->getHeader('Link'));
         $timemap_uri = NULL;
-        foreach($parsed_link_headers as $link_header){
-            if (isset($link_header['rel']) && $link_header['rel'] == "timemap") {
-                $timemap_uri = $link_header[0];
-                $timemap_uri = str_replace("<","",$timemap_uri);
-                $timemap_uri = str_replace(">","",$timemap_uri);
-            }
+        $timemap_index = array_search('timemap', array_column($parsed_link_headers, 'rel'));
+        if (is_int($timemap_index)) {
+            $timemap_uri = $parsed_link_headers[$timemap_index][0];
         }
+        $timemap_uri = trim($timemap_uri, "<> \t\n\r\0\x0B");
         return $timemap_uri;
     }
 }

--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -22,6 +22,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\HttpFoundation\Response;
+use \RuntimeException;
 
 /**
  * Default implementation of IFedoraApi using Guzzle.
@@ -323,11 +324,12 @@ class FedoraApi implements IFedoraApi
         $headers = []
     ) {
         $timemap_uri = $this->getTimemapURI($uri, $headers);
-        $options = ['http_errors' => false];
-        if ($timestamp != '') {
-            $headers['Memento-Datetime'] = $timestamp;
+        if ($timemap_uri == null) {
+            throw new \RuntimeException('Timemap URI is null, cannot create version');
         }
-        if ($content != null) {
+        $options = ['http_errors' => false];
+        if ($timestamp != '' && $content != null) {
+            $headers['Memento-Datetime'] = $timestamp;
             $options['body'] = $content;
         }
         $options['headers'] = $headers;
@@ -351,8 +353,10 @@ class FedoraApi implements IFedoraApi
         $headers = []
     ) {
         $timemap_uri = $this->getTimemapURI($uri, $headers);
+        if ($timemap_uri == null) {
+            throw new \RuntimeException('Timemap URI is null, cannot create version');
+        }
         $options = ['http_errors' => false, 'headers' => $headers];
-
         return $this->client->request(
             'GET',
             $timemap_uri,

--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -23,7 +23,6 @@ use GuzzleHttp\Psr7;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\HttpFoundation\Response;
 
-
 /**
  * Default implementation of IFedoraApi using Guzzle.
  */
@@ -325,10 +324,10 @@ class FedoraApi implements IFedoraApi
     ) {
         $timemap_uri = $this->getTimemapURI($uri, $headers);
         $options = ['http_errors' => false];
-        if ($timestamp != ''){
+        if ($timestamp != '') {
             $headers['Memento-Datetime'] = $timestamp;
         }
-        if ($content != null){
+        if ($content != null) {
             $options['body'] = $content;
         }
         $options['headers'] = $headers;

--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -312,6 +312,7 @@ class FedoraApi implements IFedoraApi
      * Creates version in Fedora.
      * @param string $uri Fedora Resource URI
      * @param string $timestamp Timestamp for Memento version
+     * @param string $content String or binary content
      * @param array $header HTTP Headers
      *
      * @return ResponseInterface
@@ -319,12 +320,16 @@ class FedoraApi implements IFedoraApi
     public function createVersion(
         $uri = '',
         $timestamp = '',
+        $content = null,
         $headers = []
     ) {
         $timemap_uri = $this->getTimemapURI($uri, $headers);
         $options = ['http_errors' => false];
         if ($timestamp != ''){
             $headers['Memento-Datetime'] = $timestamp;
+        }
+        if ($content != null){
+            $options['body'] = $content;
         }
         $options['headers'] = $headers;
 

--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -321,18 +321,7 @@ class FedoraApi implements IFedoraApi
         $timestamp = '',
         $headers = []
     ) {
-        echo("in the fedora api create version method");
-        $resource_headers = getResourceHeaders($uri, $headers);
-        $parsed_link_headers = Psr7\parse_header($resource_headers->getHeader('Link'));
-        $timemap_uri = NULL;
-        foreach($parsed_link_headers as $link_header){
-            if (isset($link_header['rel']) && $link_header['rel'] == "timemap") {
-                $timemap_uri = $link_header[0];
-                $timemap_uri = str_replace("<","",$timemap_uri);
-                $timemap_uri = str_replace(">","",$timemap_uri);
-            }
-        }
-
+        $timemap_uri = $this->getTimemapURI($uri, $headers);
         $options = ['http_errors' => false];
         if ($timestamp != ''){
             $headers['Memento-Datetime'] = $timestamp;
@@ -357,12 +346,35 @@ class FedoraApi implements IFedoraApi
         $uri = '',
         $headers = []
     ) {
+        $timemap_uri = $this->getTimemapURI($uri, $headers);
         $options = ['http_errors' => false, 'headers' => $headers];
 
         return $this->client->request(
             'GET',
-            $uri,
+            $timemap_uri,
             $options
         );
+    }
+
+    /**
+     * Helper method to get the Headers for a resource
+     * and parse the timemap header from it
+     * @param string $uri Fedora Resource URI
+     * @param array $header HTTP Headers
+     *
+     * @return string
+     */
+    private function getTimemapURI($uri, $headers){
+        $resource_headers = $this->getResourceHeaders($uri, $headers);
+        $parsed_link_headers = Psr7\parse_header($resource_headers->getHeader('Link'));
+        $timemap_uri = NULL;
+        foreach($parsed_link_headers as $link_header){
+            if (isset($link_header['rel']) && $link_header['rel'] == "timemap") {
+                $timemap_uri = $link_header[0];
+                $timemap_uri = str_replace("<","",$timemap_uri);
+                $timemap_uri = str_replace(">","",$timemap_uri);
+            }
+        }
+        return $timemap_uri;
     }
 }

--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -308,19 +308,48 @@ class FedoraApi implements IFedoraApi
 
     /**
      * Creates version in Fedora.
-     * @param string $uri Resource Versions URI
+     * @param string $uri Fedora Resource URI
+     * @param string $timestamp Timestamp for Memento version
      * @param array $header HTTP Headers
      *
      * @return ResponseInterface
      */
     public function createVersion(
         $uri = '',
+        $timestamp = '',
+        $headers = []
+    ) {
+        $resource_headers = getResourceHeaders($uri, $headers);
+        echo $resource_headers;
+
+        $options = ['http_errors' => false];
+        if ($timestamp != ''){
+            $headers['Memento-Datetime'] = $timestamp;
+        }
+        $options['headers'] = $headers;
+
+        return $this->client->request(
+            'POST',
+            $uri,
+            $options
+        );
+    }
+
+    /**
+     * Gets list of versions in Fedora.
+     * @param string $uri Fedora Resource URI
+     * @param array $header HTTP Headers
+     *
+     * @return ResponseInterface
+     */
+    public function getVersions(
+        $uri = '',
         $headers = []
     ) {
         $options = ['http_errors' => false, 'headers' => $headers];
 
         return $this->client->request(
-            'POST',
+            'GET',
             $uri,
             $options
         );

--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -19,8 +19,10 @@
 namespace Islandora\Chullo;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Psr7;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\HttpFoundation\Response;
+
 
 /**
  * Default implementation of IFedoraApi using Guzzle.
@@ -319,8 +321,17 @@ class FedoraApi implements IFedoraApi
         $timestamp = '',
         $headers = []
     ) {
+        echo("in the fedora api create version method");
         $resource_headers = getResourceHeaders($uri, $headers);
-        echo $resource_headers;
+        $parsed_link_headers = Psr7\parse_header($resource_headers->getHeader('Link'));
+        $timemap_uri = NULL;
+        foreach($parsed_link_headers as $link_header){
+            if (isset($link_header['rel']) && $link_header['rel'] == "timemap") {
+                $timemap_uri = $link_header[0];
+                $timemap_uri = str_replace("<","",$timemap_uri);
+                $timemap_uri = str_replace(">","",$timemap_uri);
+            }
+        }
 
         $options = ['http_errors' => false];
         if ($timestamp != ''){
@@ -330,7 +341,7 @@ class FedoraApi implements IFedoraApi
 
         return $this->client->request(
             'POST',
-            $uri,
+            $timemap_uri,
             $options
         );
     }

--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -369,10 +369,13 @@ class FedoraApi implements IFedoraApi
      *
      * @return string
      */
-    private function getTimemapURI($uri, $headers){
+    public function getTimemapURI(
+        $uri = '',
+        $headers = []
+    ) {
         $resource_headers = $this->getResourceHeaders($uri, $headers);
         $parsed_link_headers = Psr7\parse_header($resource_headers->getHeader('Link'));
-        $timemap_uri = NULL;
+        $timemap_uri = null;
         $timemap_index = array_search('timemap', array_column($parsed_link_headers, 'rel'));
         if (is_int($timemap_index)) {
             $timemap_uri = $parsed_link_headers[$timemap_index][0];

--- a/src/IFedoraApi.php
+++ b/src/IFedoraApi.php
@@ -134,4 +134,16 @@ interface IFedoraApi
         $uri = "",
         $headers = []
     );
+
+    /**
+     * Creates a version of the resource in Fedora.
+     *
+     * @param string    $uri            Resource URI
+     * @param array     $headers        HTTP Headers
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function createVersion(
+        $uri = "",
+        $headers = []
+    );
 }

--- a/src/IFedoraApi.php
+++ b/src/IFedoraApi.php
@@ -146,6 +146,7 @@ interface IFedoraApi
     public function createVersion(
         $uri = "",
         $timestamp = "",
+        $content = null,
         $headers = []
     );
 

--- a/src/IFedoraApi.php
+++ b/src/IFedoraApi.php
@@ -139,7 +139,7 @@ interface IFedoraApi
      * Creates a version of the resource in Fedora.
      *
      * @param string    $uri            Resource URI
-     * @param string    $timestamp      Memento Timestamp
+     * @param string    $timestamp      Timestamp in RFC-1123 format
      * @param array     $headers        HTTP Headers
      * @return \Psr\Http\Message\ResponseInterface
      */

--- a/src/IFedoraApi.php
+++ b/src/IFedoraApi.php
@@ -139,10 +139,24 @@ interface IFedoraApi
      * Creates a version of the resource in Fedora.
      *
      * @param string    $uri            Resource URI
+     * @param string    $timestamp      Memento Timestamp
      * @param array     $headers        HTTP Headers
      * @return \Psr\Http\Message\ResponseInterface
      */
     public function createVersion(
+        $uri = "",
+        $timestamp = "",
+        $headers = []
+    );
+
+    /**
+     * Creates a version of the resource in Fedora.
+     *
+     * @param string    $uri            Resource URI
+     * @param array     $headers        HTTP Headers
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function getVersions(
         $uri = "",
         $headers = []
     );

--- a/test/CreateVersionTest.php
+++ b/test/CreateVersionTest.php
@@ -13,7 +13,7 @@ class CreateVersionTest extends \PHPUnit_Framework_TestCase
 {
 
     /**
-     * @covers  Islandora\Chullo\FedoraApi::modifyResource
+     * @covers  Islandora\Chullo\FedoraApi::createVersion
      * @uses    GuzzleHttp\Client
      */
     public function testReturns201withVersions()
@@ -33,6 +33,10 @@ class CreateVersionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(201, $result->getStatusCode());
     }
 
+    /**
+     * @covers  Islandora\Chullo\FedoraApi::createVersion Exception
+     * @uses    GuzzleHttp\Client
+     */
     public function testThrowsExceptionWithoutTimemapUri()
     {
         $mock = new MockHandler(

--- a/test/CreateVersionTest.php
+++ b/test/CreateVersionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Islandora\Chullo;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Islandora\Chullo\FedoraApi;
+use \RuntimeException;
+
+class CreateVersionTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @covers  Islandora\Chullo\FedoraApi::modifyResource
+     * @uses    GuzzleHttp\Client
+     */
+    public function testReturns201withVersions()
+    {
+        $mock = new MockHandler(
+            [
+            new Response(200, ['Link' => '<http://localhost:8080/rest/path/to/resource/fcr:versions>;rel="timemap"']),
+            new Response(201, ['Location' => "SOME URI"])
+            ]
+        );
+
+        $handler = HandlerStack::create($mock);
+        $guzzle = new Client(['handler' => $handler]);
+        $api = new FedoraApi($guzzle);
+
+        $result = $api->createVersion('');
+    }
+
+    public function testThrowsExceptionWithoutTimemapUri()
+    {
+        $mock = new MockHandler(
+            [
+            new Response(200, []),
+            new Response(201, ['Location' => "SOME URI"])
+            ]
+        );
+
+        $handler = HandlerStack::create($mock);
+        $guzzle = new Client(['handler' => $handler]);
+        $api = new FedoraApi($guzzle);
+
+        $this->expectException(\RuntimeException::class);
+        $result = $api->createVersion('');
+    }
+}

--- a/test/CreateVersionTest.php
+++ b/test/CreateVersionTest.php
@@ -30,6 +30,7 @@ class CreateVersionTest extends \PHPUnit_Framework_TestCase
         $api = new FedoraApi($guzzle);
 
         $result = $api->createVersion('');
+        $this->assertEquals(201, $result->getStatusCode());
     }
 
     public function testThrowsExceptionWithoutTimemapUri()

--- a/test/CreateVersionTest.php
+++ b/test/CreateVersionTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Islandora\Chullo\FedoraApi;
 use \RuntimeException;
+use \DateTime;
 
 class CreateVersionTest extends \PHPUnit_Framework_TestCase
 {
@@ -28,8 +29,10 @@ class CreateVersionTest extends \PHPUnit_Framework_TestCase
         $handler = HandlerStack::create($mock);
         $guzzle = new Client(['handler' => $handler]);
         $api = new FedoraApi($guzzle);
-
-        $result = $api->createVersion('');
+        $date = new DateTime();
+        $timestamp = $date->format("D, d M Y H:i:s O");
+        $content = "test";
+        $result = $api->createVersion('', $timestamp, $content);
         $this->assertEquals(201, $result->getStatusCode());
     }
 

--- a/test/GetBaseUriTest.php
+++ b/test/GetBaseUriTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Islandora\Chullo;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Islandora\Chullo\FedoraApi;
+
+class GetBaseUriTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @covers  Islandora\Chullo\FedoraApi::getBaseUri
+     * @uses    GuzzleHttp\Client
+     */
+    public function testReturnsUri()
+    {
+        $guzzle = new Client(['base_uri'=>'http://localhost:8080/fcrepo/rest']);
+        $api = new FedoraApi($guzzle);
+
+        $baseUri = $api->getBaseUri();
+        $this->assertEquals($baseUri, 'http://localhost:8080/fcrepo/rest');
+    }
+}

--- a/test/GetTimemapURITest.php
+++ b/test/GetTimemapURITest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Islandora\Chullo;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Islandora\Chullo\FedoraApi;
+
+class GetTimemapURITest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @covers  Islandora\Chullo\FedoraApi::getTimemapURI
+     * @uses    GuzzleHttp\Client
+     */
+    public function testReturnsHeadersOn200()
+    {
+
+        $headers = [
+            'Status' => '200 OK',
+            'ETag' => "bbdd92e395800153a686773f773bcad80a51f47b",
+            'Last-Modified' => 'Wed, 28 May 2014 18:31:36 GMT',
+            'Link' => '<http://www.w3.org/ns/ldp#Resource>;rel="type"',
+            'Link' => '<http://www.w3.org/ns/ldp#Container>;rel="type"',
+            'Link' => '<http://localhost:8080/rest/path/to/resource/fcr:versions>;rel="timemap"',
+        ];
+
+        $mock = new MockHandler(
+            [
+            new Response(200, $headers)
+            ]
+        );
+
+        $handler = HandlerStack::create($mock);
+        $guzzle = new Client(['handler' => $handler]);
+        $api = new FedoraApi($guzzle);
+
+        $timemapuri = $api->getTimemapURI("");
+
+        $this->assertEquals("http://localhost:8080/rest/path/to/resource/fcr:versions", $timemapuri);
+    }
+}

--- a/test/GetTimemapURITest.php
+++ b/test/GetTimemapURITest.php
@@ -15,7 +15,7 @@ class GetTimemapURITest extends \PHPUnit_Framework_TestCase
      * @covers  Islandora\Chullo\FedoraApi::getTimemapURI
      * @uses    GuzzleHttp\Client
      */
-    public function testReturnsHeadersOn200()
+    public function testReturnsTimemapHeaderOn200()
     {
 
         $headers = [

--- a/test/GetVersionsTest.php
+++ b/test/GetVersionsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Islandora\Chullo;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Islandora\Chullo\FedoraApi;
+use \RuntimeException;
+
+class GetVersionsTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @covers  Islandora\Chullo\FedoraApi::getVersions
+     * @uses    GuzzleHttp\Client
+     */
+    public function testReturnsVersionsOn200()
+    {
+
+        $headers = [
+            'Status' => '200 OK',
+            'Link' => '<http://localhost:8080/rest/path/to/resource/fcr:versions>;rel="timemap"'
+        ];
+
+        $mock = new MockHandler(
+            [
+            new Response(200, $headers),
+            new Response(200, $headers)
+            ]
+        );
+
+        $handler = HandlerStack::create($mock);
+        $guzzle = new Client(['handler' => $handler]);
+        $api = new FedoraApi($guzzle);
+
+        $result = $api->getVersions();
+
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testThrowErrorWithNoTimemapURI()
+    {
+        $headers = [
+            'Status' => '200 OK'
+        ];
+
+        $mock = new MockHandler(
+            [
+                new Response(200, $headers)
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $guzzle = new Client(['handler' => $handler]);
+        $api = new FedoraApi($guzzle);
+
+        $this->expectException(\RuntimeException::class);
+        $result = $api->getVersions();
+    }
+}

--- a/test/GetVersionsTest.php
+++ b/test/GetVersionsTest.php
@@ -40,6 +40,10 @@ class GetVersionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(200, $result->getStatusCode());
     }
 
+    /**
+     * @covers  Islandora\Chullo\FedoraApi::getVersions Exception
+     * @uses    GuzzleHttp\Client
+     */
     public function testThrowErrorWithNoTimemapURI()
     {
         $headers = [


### PR DESCRIPTION
**GitHub Issue**: (https://github.com/Islandora-CLAW/CLAW/issues/740)

# What does this Pull Request do?
Bring chullo up to meet the versioning API spec

# What's new?
* add interface for new createVersion and getVersions methods
* add method for createVersion - sends a POST request to the timemapURI to create a version in Fedora. optionally sets a specific Memento-Datetime, optionally accepts the content body.
* add method for getVersions - uses timemapURI from header and makes a get request
* add a helper function to extract the timemapURI from the headers of a Fedora resource URI

# How should this be tested?
In theory, write a PHP script which calls these methods. In reality, might be easier to use Milliner in an existing Islandora site, something like - https://github.com/Islandora-CLAW/Crayfish/compare/dev...asulibraries:versioning which will hopefully be the start of a corresponding PR. 

# Additional Notes:
Fedora Versioning API Spec - https://wiki.duraspace.org/display/FEDORA5x/RESTful+HTTP+API+-+Versioning#RESTfulHTTPAPI-Versioning-BluePOSTCreateanewversionedresource(anewLDPRm)

# Interested parties
@Islandora-CLAW/committers