### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ branches:
     - /^dev/
 
 before_install:
-  - export SCRIPT_DIR=$HOME/islandora/.scripts
+  - export SCRIPT_DIR=$HOME/islandora_ci
 
 install:
-  - git clone https://github.com/Islandora/documentation.git $HOME/islandora
+  - git clone https://github.com/Islandora/islandora_ci.git $HOME/islandora_ci
   - composer install
 
 script:


### PR DESCRIPTION
**JIRA Ticket**: Part of https://github.com/Islandora/documentation/pull/1672, which is meant to clear out Islandora/documenation so that it can have looser merging privileges

# What does this Pull Request do?

Uses the newly extracted Islandora/islandora_ci for travis scripts instead of Islandora/documentation.

# How should this be tested?

Travis should be green.

# Interested parties
@Islandora/8-x-committers
