### PR TITLE
allow easyrdf to be version .9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "require": {
         "php": "^7.4",
         "guzzlehttp/guzzle": "^6.1.0",
-        "easyrdf/easyrdf": "^1",
+        "easyrdf/easyrdf": "^0.9 || ^1.0",
         "ml/json-ld": "^1.0.4"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a47def4720cb3b7e120e81f477d9278b",
+    "content-hash": "53034f62c8e08fe01f89e07a0f3ac5eb",
     "packages": [
         {
             "name": "easyrdf/easyrdf",


### PR DESCRIPTION


# What does this Pull Request do?


# What's new?
allow easyrdf to be .9 or 1.

# How should this be tested?

composer install on a d8 site - make sure dependencies are satisfied
composer install on d9 site - make sure dependencies are satisfied 


# Interested parties
 @Islandora/8-x-committers
