### PR TITLE
only alias the class if it doesn't exist?

### DIFF
--- a/src/IFedoraApi.php
+++ b/src/IFedoraApi.php
@@ -20,8 +20,8 @@ namespace Islandora\Chullo;
 use Psr\Http\Message\ResponseInterface;
 
 // phpcs:disable
-if (class_exists('\EasyRdf_Graph')) {
-    class_alias('\EasyRdf_Graph', ' \EasyRdf\Graph');
+if (class_exists('\EasyRdf_Graph') && !class_exists('\EasyRdf\Graph')) {
+    class_alias('\EasyRdf_Graph', '\EasyRdf\Graph');
 }
 // phpcs:enable
 


### PR DESCRIPTION
**GitHub Issue**: (https://github.com/Islandora/documentation/issues/1759)


# What does this Pull Request do?
Removes an annoying warning

# What's new?
* before creating the alias for the class, check if that class already exists

# How should this be tested?
* pull in PR (in the vendor directory) and make sure islandora can still talk to chullo
* make sure no more PHP warning when doing `drush cr`


# Interested parties
@Islandora/8-x-committers @mjordan @jqi26
