### PR TITLE
Update to test PHP 8

### DIFF
--- a/.github/workflows/build-1.x.yml
+++ b/.github/workflows/build-1.x.yml
@@ -19,9 +19,12 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
-        php-versions: ["7.3", "7.4"]
+        php-versions: ["7.3", "7.4", "8.0", "8.1"]
+        experimental: [false]
 
     name: PHP ${{ matrix.php-versions }}
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "issues": "https://github.com/Islandora/documentation/issues"
     },
     "require": {
-        "php": "^7.3 || ^7.4",
+        "php": ">=7.3",
         "guzzlehttp/guzzle": "^6.1.0",
         "easyrdf/easyrdf": "^0.9 || ^1",
         "ml/json-ld": "^1.0.4"


### PR DESCRIPTION
**GitHub Issue**: n/a

# What does this Pull Request do?

Updates the composer.json to allow any version of PHP greater than or equal to 7.3. Also updates the testing matrix to test PHP 7.3, 7.4, 8.0 and 8.1

# How should this be tested?

Tests pass

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
