### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/build-1.x.yml
+++ b/.github/workflows/build-1.x.yml
@@ -6,7 +6,7 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the 1.x branch
   push:
-    branches: [ 1.x ]
+    branches: [ "**" ]
   pull_request:
     branches: [ 1.x ]
 

--- a/.github/workflows/build-1.x.yml
+++ b/.github/workflows/build-1.x.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ["7.3", "7.4", "8.0", "8.1"]
+        php-versions: ["7.4", "8.0", "8.1"]
         experimental: [false]
 
     name: PHP ${{ matrix.php-versions }}
@@ -32,12 +32,12 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: build_dir
 
       - name: Checkout islandora_ci
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: islandora/islandora_ci
           ref: github-actions
@@ -53,11 +53,16 @@ jobs:
         run: |
           echo "SCRIPT_DIR=$GITHUB_WORKSPACE/islandora_ci" >> $GITHUB_ENV
 
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "composer-cache-dir=$(composer config cache-files-dir)" >> $GITHUB_ENV
+
       - name: Cache Composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: /tmp/composer-cache
-          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+          path: ${{ env.composer-cache-dir }}
+          key: ${{ runner.os }}-composer-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-${{ matrix.php-version }}
 
       - name: composer install
         run: |
@@ -73,5 +78,5 @@ jobs:
           composer test
 
       - name: Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
 

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -6,9 +6,9 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the 1.x branch
   push:
-    branches: [ 1.x ]
+    branches: [ 2.x ]
   pull_request:
-    branches: [ 1.x ]
+    branches: [ 2.x ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ["7.3", "7.4", "8.0", "8.1"]
+        php-versions: ["7.4", "8.0", "8.1"]
         experimental: [false]
 
     name: PHP ${{ matrix.php-versions }}
@@ -32,12 +32,12 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: build_dir
 
       - name: Checkout islandora_ci
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: islandora/islandora_ci
           ref: github-actions
@@ -53,11 +53,16 @@ jobs:
         run: |
           echo "SCRIPT_DIR=$GITHUB_WORKSPACE/islandora_ci" >> $GITHUB_ENV
 
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "composer-cache-dir=$(composer config cache-files-dir)" >> $GITHUB_ENV
+
       - name: Cache Composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: /tmp/composer-cache
-          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+          path: ${{ env.composer-cache-dir }}
+          key: ${{ runner.os }}-composer-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-${{ matrix.php-version }}
 
       - name: composer install
         run: |
@@ -73,5 +78,5 @@ jobs:
           composer test
 
       - name: Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
 

--- a/composer.json
+++ b/composer.json
@@ -7,16 +7,16 @@
         "issues": "https://github.com/Islandora/documentation/issues"
     },
     "require": {
-        "php": ">=7.3",
-        "guzzlehttp/guzzle": "^6.1.0",
-        "easyrdf/easyrdf": "^0.9 || ^1",
+        "php": ">=7.4",
+        "guzzlehttp/guzzle": "^7.4",
+        "easyrdf/easyrdf": "^1",
         "ml/json-ld": "^1.0.4"
     },
     "require-dev": {
+        "donatj/mock-webserver": "^2.6",
         "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.0",
-        "sebastian/phpcpd": "^6.0",
-        "mockery/mockery": "^0.9"
+        "sebastian/phpcpd": "^6.0"
     },
     "scripts": {
         "check": [
@@ -48,6 +48,13 @@
         }
     ],
     "autoload": {
-        "psr-4": {"Islandora\\Chullo\\": "src/"}
+        "psr-4": {
+            "Islandora\\Chullo\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Islandora\\Chullo\\Test\\": "test/"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "require": {
         "php": ">=7.4",
-        "guzzlehttp/guzzle": "^7.4",
+        "guzzlehttp/guzzle": "^6.5 || ^7.4",
         "easyrdf/easyrdf": "^1",
         "ml/json-ld": "^1.0.4"
     },

--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -18,68 +18,66 @@
 
 namespace Islandora\Chullo;
 
+use EasyRdf\Graph;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\ResponseInterface;
-use Symfony\Component\HttpFoundation\Response;
 use \RuntimeException;
 
-// phpcs:disable
-if (class_exists('\EasyRdf_Graph')) {
-    class_alias('\EasyRdf_Graph', ' \EasyRdf\Graph');
-}
-// phpcs:enable
-
-//
 /**
  * Default implementation of IFedoraApi using Guzzle.
  */
 class FedoraApi implements IFedoraApi
 {
 
-    protected $client;
+    /**
+     * The client.
+     *
+     * @var \GuzzleHttp\Client
+     */
+    private Client $client;
+
+    /**
+     * Fedora Base URI.
+     *
+     * @var string
+     */
+    private string $base_uri;
 
     /**
      * @codeCoverageIgnore
      */
-    public function __construct(Client $client)
+    private function __construct(string $uri)
     {
-        $this->client = $client;
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public static function create($fedora_rest_url)
-    {
-        $normalized = rtrim($fedora_rest_url);
+        $normalized = rtrim($uri);
         $normalized = rtrim($normalized, '/') . '/';
-        $guzzle = new Client(['base_uri' => $normalized]);
-        return new static($guzzle);
+        $this->client = new Client(['base_uri' => $normalized]);
+        $this->base_uri = $normalized;
     }
 
     /**
-     * Gets the Fedora base uri (e.g. http://localhost:8080/fcrepo/rest)
-     *
-     * @return string
+     * @codeCoverageIgnore
      */
-    public function getBaseUri()
+    public static function create(string $fedora_rest_url): self
     {
-        return $this->client->getConfig('base_uri');
+        return new static($fedora_rest_url);
     }
 
     /**
-     * Gets a Fedora resource.
-     *
-     * @param string    $uri            Resource URI
-     * @param array     $headers        HTTP Headers
-     *
-     * @return ResponseInterface
+     * @inheritDoc
+     */
+    public function getBaseUri(): string
+    {
+        return $this->base_uri;
+    }
+
+    /**
+     * @inheritDoc
      */
     public function getResource(
-        $uri = "",
-        $headers = []
-    ) {
+        string $uri = "",
+        array $headers = []
+    ): ResponseInterface {
         // Set headers
         $options = ['http_errors' => false, 'headers' => $headers];
 
@@ -92,18 +90,12 @@ class FedoraApi implements IFedoraApi
     }
 
     /**
-     * Gets a Fedora resoure's headers.
-     *
-     * @param string    $uri            Resource URI
-     * @param array     $headers        HTTP Headers
-     *
-     * @return ResponseInterface
+     * @inheritDoc
      */
     public function getResourceHeaders(
-        $uri = "",
-        $headers = []
-    ) {
-
+        string $uri = "",
+        array $headers = []
+    ): ResponseInterface {
         // Send the request.
         return $this->client->request(
             'HEAD',
@@ -113,17 +105,12 @@ class FedoraApi implements IFedoraApi
     }
 
     /**
-     * Gets information about the supported HTTP methods, etc., for a Fedora resource.
-     *
-     * @param string    $uri            Resource URI
-     * @param array     $headers        HTTP Headers
-     *
-     * @return ResponseInterface
+     * @inheritDoc
      */
     public function getResourceOptions(
-        $uri = "",
-        $headers = []
-    ) {
+        string $uri = "",
+        array $headers = []
+    ): ResponseInterface {
         return $this->client->request(
             'OPTIONS',
             $uri,
@@ -132,19 +119,13 @@ class FedoraApi implements IFedoraApi
     }
 
     /**
-     * Creates a new resource in Fedora.
-     *
-     * @param string    $uri                  Resource URI
-     * @param string    $content              String or binary content
-     * @param array     $headers              HTTP Headers
-     *
-     * @return ResponseInterface
+     * @inheritDoc
      */
     public function createResource(
-        $uri = "",
-        $content = null,
-        $headers = []
-    ) {
+        string $uri = "",
+        ?string $content = null,
+        array $headers = []
+    ): ResponseInterface {
         $options = ['http_errors' => false];
 
         // Set content.
@@ -161,19 +142,13 @@ class FedoraApi implements IFedoraApi
     }
 
     /**
-     * Saves a resource in Fedora.
-     *
-     * @param string    $uri                  Resource URI
-     * @param string    $content              String or binary content
-     * @param array     $headers              HTTP Headers
-     *
-     * @return ResponseInterface
+     * @inheritDoc
      */
     public function saveResource(
-        $uri,
-        $content = null,
-        $headers = []
-    ) {
+        string $uri,
+        ?string $content = null,
+        array $headers = []
+    ): ResponseInterface {
         $options = ['http_errors' => false];
 
         // Set content.
@@ -190,19 +165,13 @@ class FedoraApi implements IFedoraApi
     }
 
     /**
-     * Modifies a resource using a SPARQL Update query.
-     *
-     * @param string    $uri            Resource URI
-     * @param string    $sparql         SPARQL Update query
-     * @param array     $headers        HTTP Headers
-     *
-     * @return ResponseInterface
+     * @inheritDoc
      */
     public function modifyResource(
-        $uri,
-        $sparql = "",
-        $headers = []
-    ) {
+        string $uri,
+        string $sparql = "",
+        array $headers = []
+    ): ResponseInterface {
         $options = ['http_errors' => false];
 
         // Set content.
@@ -220,17 +189,12 @@ class FedoraApi implements IFedoraApi
     }
 
     /**
-     * Issues a DELETE request to Fedora.
-     *
-     * @param string    $uri            Resource URI
-     * @param array     $headers        HTTP Headers
-     *
-     * @return ResponseInterface
+     * @inheritDoc
      */
     public function deleteResource(
-        $uri = '',
-        $headers = []
-    ) {
+        string $uri = '',
+        array $headers = []
+    ): ResponseInterface {
         $options = ['http_errors' => false, 'headers' => $headers];
 
         return $this->client->request(
@@ -241,19 +205,13 @@ class FedoraApi implements IFedoraApi
     }
 
     /**
-     * Saves RDF in Fedora.
-     *
-     * @param EasyRdf_Resource  $graph          Graph to save
-     * @param string            $uri            Resource URI
-     * @param array             $headers        HTTP Headers
-     *
-     * @return ResponseInterface
+     * @inheritDoc
      */
     public function saveGraph(
-        \EasyRdf\Graph $graph,
-        $uri = '',
-        $headers = []
-    ) {
+        Graph $graph,
+        string $uri = '',
+        array $headers = []
+    ): ResponseInterface {
         // Serialze the rdf.
         $turtle = $graph->serialise('turtle');
 
@@ -269,20 +227,14 @@ class FedoraApi implements IFedoraApi
     }
 
     /**
-     * Creates RDF in Fedora.
-     *
-     * @param EasyRdf_Resource  $graph          Graph to save
-     * @param string            $uri            Resource URI
-     * @param array             $headers        HTTP Headers
-     *
-     * @return ResponseInterface
+     * @inheritDoc
      */
     public function createGraph(
-        \EasyRdf\Graph $graph,
-        $uri = '',
-        $headers = []
-    ) {
-        // Serialze the rdf.
+        Graph $graph,
+        string $uri = '',
+        array $headers = []
+    ): ResponseInterface {
+        // Serialize the rdf.
         $turtle = $graph->serialise('turtle');
 
         // Checksum it.
@@ -296,19 +248,14 @@ class FedoraApi implements IFedoraApi
         return $this->createResource($uri, $turtle, $headers);
     }
 
-
     /**
-     * Gets RDF in Fedora.
-     *
-     * @param ResponseInterface   $request    Response received
-     *
-     * @return \EasyRdf\Graph
+     * @inheritDoc
      */
-    public function getGraph(ResponseInterface $response)
+    public function getGraph(ResponseInterface $response): Graph
     {
         // Extract rdf as response body and return Easy_RDF Graph object.
         $rdf = $response->getBody()->getContents();
-        $graph = new \EasyRdf\Graph();
+        $graph = new Graph();
         if (!empty($rdf)) {
             $graph->parse($rdf, 'jsonld');
         }
@@ -316,23 +263,19 @@ class FedoraApi implements IFedoraApi
     }
 
     /**
-     * Creates version in Fedora.
-     * @param string $uri Fedora Resource URI
-     * @param string $timestamp Timestamp for Memento version
-     * @param string $content String or binary content
-     * @param array $header HTTP Headers
-     *
-     * @return ResponseInterface
+     * @inheritDoc
      */
     public function createVersion(
         $uri = '',
         $timestamp = '',
         $content = null,
         $headers = []
-    ) {
+    ): ResponseInterface {
         $timemap_uri = $this->getTimemapURI($uri, $headers);
         if ($timemap_uri == null) {
-            throw new \RuntimeException('Timemap URI is null, cannot create version');
+            throw new RuntimeException(
+                'Timemap URI is null, cannot create version'
+            );
         }
         $options = ['http_errors' => false];
         if ($timestamp != '' && $content != null) {
@@ -349,44 +292,43 @@ class FedoraApi implements IFedoraApi
     }
 
     /**
-     * Gets list of versions in Fedora.
-     * @param string $uri Fedora Resource URI
-     * @param array $header HTTP Headers
-     *
-     * @return ResponseInterface
+     * @inheritDoc
      */
     public function getVersions(
         $uri = '',
         $headers = []
-    ) {
+    ): ResponseInterface {
         $timemap_uri = $this->getTimemapURI($uri, $headers);
         if ($timemap_uri == null) {
-            throw new \RuntimeException('Timemap URI is null, cannot create version');
+            throw new RuntimeException(
+                'Timemap URI is null, cannot create version'
+            );
         }
-        $options = ['http_errors' => false, 'headers' => $headers];
-        return $this->client->request(
-            'GET',
-            $timemap_uri,
-            $options
-        );
+
+        return $this->getResource($timemap_uri, $headers);
     }
 
     /**
      * Helper method to get the Headers for a resource
      * and parse the timemap header from it
      * @param string $uri Fedora Resource URI
-     * @param array $header HTTP Headers
+     * @param array $headers HTTP Headers
      *
-     * @return string
+     * @return string|null
      */
     public function getTimemapURI(
-        $uri = '',
-        $headers = []
-    ) {
+        string $uri = '',
+        array $headers = []
+    ): ?string {
         $resource_headers = $this->getResourceHeaders($uri, $headers);
-        $parsed_link_headers = Psr7\parse_header($resource_headers->getHeader('Link'));
+        $parsed_link_headers = Psr7\Header::parse(
+            $resource_headers->getHeader('Link')
+        );
         $timemap_uri = null;
-        $timemap_index = array_search('timemap', array_column($parsed_link_headers, 'rel'));
+        $timemap_index = array_search(
+            'timemap',
+            array_column($parsed_link_headers, 'rel')
+        );
         if (is_int($timemap_index)) {
             $timemap_uri = $parsed_link_headers[$timemap_index][0];
             $timemap_uri = trim($timemap_uri, "<> \t\n\r\0\x0B");

--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -136,7 +136,7 @@ class FedoraApi implements IFedoraApi
      */
     public function createResource(
         string $uri = "",
-        ?string $content = null,
+        $content = null,
         array $headers = []
     ): ResponseInterface {
         $options = ['http_errors' => false];
@@ -159,7 +159,7 @@ class FedoraApi implements IFedoraApi
      */
     public function saveResource(
         string $uri,
-        ?string $content = null,
+        $content = null,
         array $headers = []
     ): ResponseInterface {
         $options = ['http_errors' => false];

--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -20,6 +20,7 @@ namespace Islandora\Chullo;
 
 use EasyRdf\Graph;
 use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\ResponseInterface;
 use \RuntimeException;
@@ -47,11 +48,15 @@ class FedoraApi implements IFedoraApi
     /**
      * @codeCoverageIgnore
      */
-    private function __construct(string $uri)
+    private function __construct(string $uri, ?HandlerStack $stack)
     {
         $normalized = rtrim($uri);
         $normalized = rtrim($normalized, '/') . '/';
-        $this->client = new Client(['base_uri' => $normalized]);
+        $guzzle_opts = ['base_uri' => $normalized];
+        if (!is_null($stack)) {
+            $guzzle_opts['handler'] = $stack;
+        }
+        $this->client = new Client($guzzle_opts);
         $this->base_uri = $normalized;
     }
 
@@ -60,7 +65,15 @@ class FedoraApi implements IFedoraApi
      */
     public static function create(string $fedora_rest_url): self
     {
-        return new static($fedora_rest_url);
+        return new static($fedora_rest_url, null);
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public static function createWithHandler(string $fedora_rest_url, HandlerStack $stack): self
+    {
+        return new static($fedora_rest_url, $stack);
     }
 
     /**

--- a/src/IFedoraApi.php
+++ b/src/IFedoraApi.php
@@ -72,13 +72,13 @@ interface IFedoraApi
      * Creates a new resource in Fedora.
      *
      * @param string      $uri                  Resource URI
-     * @param string|null $content              String or binary content
+     * @param mixed|null $content              String, resource from fopen() or stream content
      * @param array       $headers              HTTP Headers
      * @return \Psr\Http\Message\ResponseInterface
      */
     public function createResource(
         string $uri = "",
-        ?string $content = null,
+        $content = null,
         array $headers = []
     ): ResponseInterface;
 
@@ -86,13 +86,13 @@ interface IFedoraApi
      * Saves a resource in Fedora.
      *
      * @param string      $uri                  Resource URI
-     * @param string|null $content              String or binary content
+     * @param mixed|null $content               String, resource from fopen() or stream content
      * @param array       $headers              HTTP Headers
      * @return \Psr\Http\Message\ResponseInterface
      */
     public function saveResource(
         string $uri,
-        ?string $content = null,
+        $content = null,
         array $headers = []
     ): ResponseInterface;
 

--- a/src/IFedoraApi.php
+++ b/src/IFedoraApi.php
@@ -17,13 +17,8 @@
 
 namespace Islandora\Chullo;
 
+use EasyRdf\Graph;
 use Psr\Http\Message\ResponseInterface;
-
-// phpcs:disable
-if (class_exists('\EasyRdf_Graph') && !class_exists('\EasyRdf\Graph')) {
-    class_alias('\EasyRdf_Graph', '\EasyRdf\Graph');
-}
-// phpcs:enable
 
 /**
  * Interface for Fedora interaction.  All functions return a PSR-7 response.
@@ -35,19 +30,19 @@ interface IFedoraApi
      *
      * @return string
      */
-    public function getBaseUri();
+    public function getBaseUri(): string;
 
     /**
      * Gets a Fedora resource.
      *
-     * @param string    $uri            Resource URI
-     * @param array     $headers        HTTP Headers
+     * @param string $uri            Resource URI
+     * @param array  $headers        HTTP Headers
      * @return \Psr\Http\Message\ResponseInterface
      */
     public function getResource(
-        $uri = "",
-        $headers = []
-    );
+        string $uri = "",
+        array $headers = []
+    ): ResponseInterface;
 
     /**
      * Gets a Fedora resoure's headers.
@@ -57,9 +52,9 @@ interface IFedoraApi
      * @return \Psr\Http\Message\ResponseInterface
      */
     public function getResourceHeaders(
-        $uri = "",
-        $headers = []
-    );
+        string $uri = "",
+        array $headers = []
+    ): ResponseInterface;
 
     /**
      * Gets information about the supported HTTP methods, etc., for a Fedora resource.
@@ -69,37 +64,37 @@ interface IFedoraApi
      * @return \Psr\Http\Message\ResponseInterface
      */
     public function getResourceOptions(
-        $uri = "",
-        $headers = []
-    );
+        string $uri = "",
+        array $headers = []
+    ): ResponseInterface;
 
     /**
      * Creates a new resource in Fedora.
      *
-     * @param string    $uri                  Resource URI
-     * @param string    $content              String or binary content
-     * @param array     $headers              HTTP Headers
+     * @param string      $uri                  Resource URI
+     * @param string|null $content              String or binary content
+     * @param array       $headers              HTTP Headers
      * @return \Psr\Http\Message\ResponseInterface
      */
     public function createResource(
-        $uri = "",
-        $content = null,
-        $headers = []
-    );
+        string $uri = "",
+        ?string $content = null,
+        array $headers = []
+    ): ResponseInterface;
 
     /**
      * Saves a resource in Fedora.
      *
-     * @param string    $uri                  Resource URI
-     * @param string    $content              String or binary content
-     * @param array     $headers              HTTP Headers
+     * @param string      $uri                  Resource URI
+     * @param string|null $content              String or binary content
+     * @param array       $headers              HTTP Headers
      * @return \Psr\Http\Message\ResponseInterface
      */
     public function saveResource(
-        $uri,
-        $content = null,
-        $headers = []
-    );
+        string $uri,
+        ?string $content = null,
+        array $headers = []
+    ): ResponseInterface;
 
     /**
      * Modifies a resource using a SPARQL Update query.
@@ -110,10 +105,10 @@ interface IFedoraApi
      * @return \Psr\Http\Message\ResponseInterface
      */
     public function modifyResource(
-        $uri,
-        $sparql = "",
-        $headers = []
-    );
+        string $uri,
+        string $sparql = "",
+        array $headers = []
+    ): ResponseInterface;
 
     /**
      * Issues a DELETE request to Fedora.
@@ -123,38 +118,64 @@ interface IFedoraApi
      * @return \Psr\Http\Message\ResponseInterface
      */
     public function deleteResource(
-        $uri = "",
-        $headers = []
-    );
+        string $uri = "",
+        array $headers = []
+    ): ResponseInterface;
 
     /**
      * Saves RDF in Fedora.
      *
-     * @param EasyRdf_Resource  $rdf            Graph to save
+     * @param \EasyRdf\Graph    $graph          Graph to save
      * @param string            $uri            Resource URI
      * @param array             $headers        HTTP Headers
      * @return \Psr\Http\Message\ResponseInterface
      */
     public function saveGraph(
-        \EasyRdf\Graph $graph,
-        $uri = "",
-        $headers = []
-    );
+        Graph $graph,
+        string $uri = "",
+        array $headers = []
+    ): ResponseInterface;
+
+    /**
+     * Creates RDF in Fedora.
+     *
+     * @param \EasyRdf\Graph $graph    Graph to save
+     * @param string         $uri      Resource URI
+     * @param array          $headers  HTTP Headers
+     *
+     * @return ResponseInterface
+     */
+    public function createGraph(
+        Graph $graph,
+        string $uri = '',
+        array $headers = []
+    ): ResponseInterface;
+
+    /**
+     * Gets RDF in Fedora.
+     *
+     * @param ResponseInterface $response Response received
+     *
+     * @return \EasyRdf\Graph
+     * @throws \EasyRdf\Exception Unable to parse graph.
+     */
+    public function getGraph(ResponseInterface $response): Graph;
 
     /**
      * Creates a version of the resource in Fedora.
      *
-     * @param string    $uri            Resource URI
-     * @param string    $timestamp      Timestamp in RFC-1123 format
-     * @param array     $headers        HTTP Headers
+     * @param string      $uri            Resource URI
+     * @param string      $timestamp      Timestamp in RFC-1123 format
+     * @param string|null $content        Content for the version
+     * @param array       $headers        HTTP Headers
      * @return \Psr\Http\Message\ResponseInterface
      */
     public function createVersion(
-        $uri = "",
-        $timestamp = "",
-        $content = null,
-        $headers = []
-    );
+        string $uri = "",
+        string $timestamp = "",
+        ?string $content = null,
+        array $headers = []
+    ): ResponseInterface;
 
     /**
      * Creates a version of the resource in Fedora.
@@ -164,7 +185,7 @@ interface IFedoraApi
      * @return \Psr\Http\Message\ResponseInterface
      */
     public function getVersions(
-        $uri = "",
-        $headers = []
-    );
+        string $uri = "",
+        array $headers = []
+    ): ResponseInterface;
 }

--- a/test/ChulloTestBase.php
+++ b/test/ChulloTestBase.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Islandora\Chullo\Test;
+
+use donatj\MockWebServer\MockWebServer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test base for Chullo to setup the mock webserver.
+ */
+class ChulloTestBase extends TestCase
+{
+
+    protected static $webserver;
+
+    /**
+     * @inheritDoc
+     */
+    public static function setUpBeforeClass(): void
+    {
+        self::$webserver = new MockWebServer();
+        self::$webserver->start();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function tearDownAfterClass(): void
+    {
+        self::$webserver->stop();
+    }
+}

--- a/test/CreateClientTest.php
+++ b/test/CreateClientTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Islandora\Chullo\Test;
+
+use donatj\MockWebServer\Response;
+use GuzzleHttp\Handler\CurlHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use Islandora\Chullo\FedoraApi;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Test of the createWithHandler method.
+ */
+class CreateClientTest extends ChulloTestBase
+{
+    public function testAddHeader(): void
+    {
+        $test_uri = self::$webserver->setResponseOfPath(
+            "/rest/path/to/resource",
+            new Response(
+                "SOME CONTENT",
+                ['X-FOO' => 'Fedora4'],
+                200
+            )
+        );
+
+        $stack = HandlerStack::create();
+        $stack->setHandler(new CurlHandler());
+
+        $stack->push(Middleware::mapResponse(function (ResponseInterface $response) {
+            return $response->withHeader('X-ISLANDORA', 'my header');
+        }));
+
+        $api = FedoraApi::createWithHandler(self::$webserver->getHost(), $stack);
+
+        $result = $api->getResource($test_uri);
+        $this->assertSame((string)$result->getBody(), "SOME CONTENT");
+        $this->assertSame($result->getHeader('X-FOO'), ['Fedora4']);
+        $this->assertSame($result->getHeader('X-ISLANDORA'), ['my header']);
+    }
+}

--- a/test/CreateGraphTest.php
+++ b/test/CreateGraphTest.php
@@ -1,32 +1,36 @@
 <?php
 
-namespace Islandora\Chullo;
+namespace Islandora\Chullo\Test;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
+use donatj\MockWebServer\Response;
+use donatj\MockWebServer\ResponseByMethod;
+use EasyRdf\Graph;
 use Islandora\Chullo\FedoraApi;
-use PHPUnit\Framework\TestCase;
 
-class CreateGraphTest extends TestCase
+class CreateGraphTest extends ChulloTestBase
 {
 
     /**
-     * @covers  Islandora\Chullo\FedoraApi::createGraph
-     * @uses    GuzzleHttp\Client
+     * @covers  \Islandora\Chullo\FedoraApi::createGraph
+     * @uses    \GuzzleHttp\Client
      */
     public function testReturnsTrueOn204()
     {
-        $mock = new MockHandler([
-            new Response(204),
-        ]);
+        $test_uri = self::$webserver->setResponseOfPath(
+            "/test_create",
+            new ResponseByMethod([
+                ResponseByMethod::METHOD_POST =>
+                    new Response(
+                        "",
+                        [],
+                        204
+                    )
+            ])
+        );
 
-        $handler = HandlerStack::create($mock);
-        $guzzle = new Client(['handler' => $handler]);
-        $api = new FedoraApi($guzzle);
+        $api = FedoraApi::create(self::$webserver->getHost());
 
-        $result = $api->createGraph(new \EasyRdf\Graph());
+        $result = $api->createGraph(new Graph(), $test_uri);
         $this->assertEquals(204, $result->getStatusCode());
     }
 }

--- a/test/CreateResourceTest.php
+++ b/test/CreateResourceTest.php
@@ -1,34 +1,35 @@
 <?php
 
-namespace Islandora\Chullo;
+namespace Islandora\Chullo\Test;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
+use donatj\MockWebServer\Response;
+use donatj\MockWebServer\ResponseByMethod;
 use Islandora\Chullo\FedoraApi;
-use PHPUnit\Framework\TestCase;
 
-class CreateResourceTest extends TestCase
+class CreateResourceTest extends ChulloTestBase
 {
 
     /**
-     * @covers  Islandora\Chullo\FedoraApi::createResource
-     * @uses    GuzzleHttp\Client
+     * @covers  \Islandora\Chullo\FedoraApi::createResource
+     * @uses    \GuzzleHttp\Client
      */
     public function testReturnsUriOn201()
     {
-        $mock = new MockHandler(
-            [
-            new Response(201, ['Location' => "SOME URI"]),
-            ]
+        $test_uri = self::$webserver->setResponseOfPath(
+            '/some_uri',
+            new ResponseByMethod([
+                ResponseByMethod::METHOD_POST =>
+                    new Response(
+                        "",
+                        ['Location' => "SOME URI"],
+                        201
+                    )
+            ])
         );
 
-        $handler = HandlerStack::create($mock);
-        $guzzle = new Client(['handler' => $handler]);
-        $api = new FedoraApi($guzzle);
+        $api = FedoraApi::create(self::$webserver->getHost());
 
-        $result = $api->createResource("");
+        $result = $api->createResource($test_uri);
         $this->assertEquals($result->getHeaderLine("Location"), "SOME URI");
         $this->assertEquals(201, $result->getStatusCode(), "Expected a 201 response.");
     }

--- a/test/DeleteResourceTest.php
+++ b/test/DeleteResourceTest.php
@@ -1,32 +1,35 @@
 <?php
 
-namespace Islandora\Chullo;
+namespace Islandora\Chullo\Test;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
+use donatj\MockWebServer\Response;
+use donatj\MockWebServer\ResponseByMethod;
 use Islandora\Chullo\FedoraApi;
-use PHPUnit\Framework\TestCase;
 
-class DeleteResourceTest extends TestCase
+class DeleteResourceTest extends ChulloTestBase
 {
 
     /**
-     * @covers  Islandora\Chullo\FedoraApi::deleteResource
-     * @uses    GuzzleHttp\Client
+     * @covers  \Islandora\Chullo\FedoraApi::deleteResource
+     * @uses    \GuzzleHttp\Client
      */
     public function testReturnsTrueOn204()
     {
-        $mock = new MockHandler([
-            new Response(204),
-        ]);
+        $test_uri = self::$webserver->setResponseOfPath(
+            '/rest/some/path',
+            new ResponseByMethod([
+                ResponseByMethod::METHOD_DELETE =>
+                    new Response(
+                        "",
+                        [],
+                        204
+                    ),
+            ])
+        );
 
-        $handler = HandlerStack::create($mock);
-        $guzzle = new Client(['handler' => $handler]);
-        $api = new FedoraApi($guzzle);
+        $api = FedoraApi::create(self::$webserver->getHost());
 
-        $result = $api->deleteResource("");
+        $result = $api->deleteResource($test_uri);
         $this->assertEquals(204, $result->getStatusCode());
     }
 }

--- a/test/GetBaseUriTest.php
+++ b/test/GetBaseUriTest.php
@@ -1,27 +1,24 @@
 <?php
 
-namespace Islandora\Chullo;
+namespace Islandora\Chullo\Test;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
 use Islandora\Chullo\FedoraApi;
-use PHPUnit\Framework\TestCase;
 
-class GetBaseUriTest extends TestCase
+class GetBaseUriTest extends ChulloTestBase
 {
 
     /**
-     * @covers  Islandora\Chullo\FedoraApi::getBaseUri
-     * @uses    GuzzleHttp\Client
+     * @covers  \Islandora\Chullo\FedoraApi::getBaseUri
+     * @uses    \GuzzleHttp\Client
      */
     public function testReturnsUri()
     {
-        $guzzle = new Client(['base_uri'=>'http://localhost:8080/fcrepo/rest']);
-        $api = new FedoraApi($guzzle);
+        $input = 'http://localhost:8080/fcrepo/rest';
+        $api = FedoraApi::create($input);
+        # Base Uri always has a forward slash on the end.
+        $expected = 'http://localhost:8080/fcrepo/rest/';
 
         $baseUri = $api->getBaseUri();
-        $this->assertEquals($baseUri, 'http://localhost:8080/fcrepo/rest');
+        $this->assertEquals($expected, $baseUri);
     }
 }

--- a/test/GetGraphTest.php
+++ b/test/GetGraphTest.php
@@ -1,20 +1,21 @@
 <?php
 
-namespace Islandora\Chullo;
+namespace Islandora\Chullo\Test;
 
+use donatj\MockWebServer\Response;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
+
 use Islandora\Chullo\FedoraApi;
 use PHPUnit\Framework\TestCase;
 
-class GetGraphTest extends TestCase
+class GetGraphTest extends ChulloTestBase
 {
 
     /**
-     * @covers  Islandora\Chullo\FedoraApi::getGraph
-     * @uses    GuzzleHttp\Client
+     * @covers  \Islandora\Chullo\FedoraApi::getGraph
+     * @uses    \GuzzleHttp\Client
      */
     public function testReturnsContentOn200()
     {
@@ -70,15 +71,18 @@ class GetGraphTest extends TestCase
               } ]
             } ]
 EOD;
-        $mock = new MockHandler([
-            new Response(200, ['Content-Type' => 'application/ld+json'], $fixture),
-        ]);
+        $test_uri = self::$webserver->setResponseOfPath(
+            "/rest/path/to/resource",
+            new Response(
+                $fixture,
+                ['Content-Type' => 'application/ld+json'],
+                200
+            )
+        );
 
-        $handler = HandlerStack::create($mock);
-        $guzzle = new Client(['handler' => $handler]);
-        $api = new FedoraApi($guzzle);
+        $api = FedoraApi::create(self::$webserver->getHost());
 
-        $result = $api->getResource("");
+        $result = $api->getResource($test_uri);
 
         $graph = $api->getGraph($result);
         $title = (string)$graph->get(

--- a/test/GetResourceHeadersTest.php
+++ b/test/GetResourceHeadersTest.php
@@ -1,24 +1,19 @@
 <?php
 
-namespace Islandora\Chullo;
+namespace Islandora\Chullo\Test;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
+use donatj\MockWebServer\Response;
 use Islandora\Chullo\FedoraApi;
-use PHPUnit\Framework\TestCase;
 
-class GetResourceHeadersTest extends TestCase
+class GetResourceHeadersTest extends ChulloTestBase
 {
 
     /**
-     * @covers  Islandora\Chullo\FedoraApi::getResourceHeaders
-     * @uses    GuzzleHttp\Client
+     * @covers  \Islandora\Chullo\FedoraApi::getResourceHeaders
+     * @uses    \GuzzleHttp\Client
      */
     public function testReturnsHeadersOn200()
     {
-
         $headers = [
             'Status' => '200 OK',
             'ETag' => "bbdd92e395800153a686773f773bcad80a51f47b",
@@ -31,18 +26,18 @@ class GetResourceHeadersTest extends TestCase
                 'multipart/form-data,application/sparql-update',
             'Allow' => 'MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS',
         ];
-
-        $mock = new MockHandler(
-            [
-            new Response(200, $headers)
-            ]
+        $test_uri = self::$webserver->setResponseOfPath(
+            "/rest/path/to/resource",
+            new Response(
+                "",
+                $headers,
+                200
+            )
         );
 
-        $handler = HandlerStack::create($mock);
-        $guzzle = new Client(['handler' => $handler]);
-        $api = new FedoraApi($guzzle);
+        $api =  FedoraApi::create(self::$webserver->getHost());
 
-        $result = $api->getResourceHeaders("");
+        $result = $api->getResourceHeaders($test_uri);
 
         $this->assertEquals(200, $result->getStatusCode());
         $this->assertTrue($result->hasHeader("etag"));

--- a/test/GetResourceOptionsTest.php
+++ b/test/GetResourceOptionsTest.php
@@ -1,20 +1,16 @@
 <?php
 
-namespace Islandora\Chullo;
+namespace Islandora\Chullo\Test;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
+use donatj\MockWebServer\Response;
 use Islandora\Chullo\FedoraApi;
-use PHPUnit\Framework\TestCase;
 
-class GetResourceOptionsTest extends TestCase
+class GetResourceOptionsTest extends ChulloTestBase
 {
 
     /**
-     * @covers  Islandora\Chullo\FedoraApi::getResourceOptions
-     * @uses    GuzzleHttp\Client
+     * @covers  \Islandora\Chullo\FedoraApi::getResourceOptions
+     * @uses    \GuzzleHttp\Client
      */
     public function testReturnsHeadersOn200()
     {
@@ -25,15 +21,13 @@ class GetResourceOptionsTest extends TestCase
             'Accept-Post' => 'text/turtle,text/rdf+n3,application/n3,text/n3,application/rdf+xml,' .
                 'application/n-triples,multipart/form-data,application/sparql-update',
         ];
-        $mock = new MockHandler([
-          new Response(200, $headers),
-        ]);
+        $test_uri = self::$webserver->setResponseOfPath(
+            "/test_options",
+            new Response("", $headers, 200)
+        );
+        $api = FedoraApi::create(self::$webserver->getHost());
 
-        $handler = HandlerStack::create($mock);
-        $guzzle = new Client(['handler' => $handler]);
-        $api = new FedoraApi($guzzle);
-
-        $result = $api->getResourceOptions("");
+        $result = $api->getResourceOptions($test_uri);
         $this->assertEquals(200, $result->getStatusCode());
         $this->assertEquals($headers['Allow'], $result->getHeaderLine('allow'));
         $this->assertEquals($headers['Accept-Patch'], $result->getHeaderLine('accept-patch'));

--- a/test/GetResourceTest.php
+++ b/test/GetResourceTest.php
@@ -1,58 +1,67 @@
 <?php
 
-namespace Islandora\Chullo;
+namespace Islandora\Chullo\Test;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
+use donatj\MockWebServer\Response;
 use Islandora\Chullo\FedoraApi;
-use PHPUnit\Framework\TestCase;
 
-class GetResourceTest extends TestCase
+class GetResourceTest extends ChulloTestBase
 {
 
     /**
-     * @covers  Islandora\Chullo\FedoraApi::getResource
-     * @uses    GuzzleHttp\Client
+     * @covers  \Islandora\Chullo\FedoraApi::getResource
+     * @uses    \GuzzleHttp\Client
      */
     public function testReturnsApiContentOn200()
     {
-        $mock = new MockHandler([
-            new Response(200, ['X-FOO' => 'Fedora4'], "SOME CONTENT"),
-        ]);
+        $test_uri = self::$webserver->setResponseOfPath(
+            "/rest/path/to/resource",
+            new Response(
+                "SOME CONTENT",
+                ['X-FOO' => 'Fedora4'],
+                200
+            )
+        );
 
-        $handler = HandlerStack::create($mock);
-        $guzzle = new Client(['handler' => $handler]);
-        $api = new FedoraApi($guzzle);
-        $result = $api->getResource("");
+        $api = FedoraApi::create(self::$webserver->getHost());
+        $result = $api->getResource($test_uri);
         $this->assertSame((string)$result->getBody(), "SOME CONTENT");
         $this->assertSame($result->getHeader('X-FOO'), ['Fedora4']);
     }
 
     /**
-     * @covers  Islandora\Chullo\FedoraApi::getResource
-     * @uses    GuzzleHttp\Client
+     * @covers  \Islandora\Chullo\FedoraApi::getResource
+     * @uses    \GuzzleHttp\Client
      *
      * TODO: Is this useful anymore?
      */
     public function testReturnsNullOtherwise()
     {
-        $mock = new MockHandler([
-            new Response(304),
-            new Response(404),
-        ]);
+        $test_uri1 = self::$webserver->setResponseOfPath(
+            "/rest/path/to/resource1",
+            new Response(
+                "",
+                [],
+                304
+            )
+        );
+        $test_uri2 = self::$webserver->setResponseOfPath(
+            "/rest/path/to/resource2",
+            new Response(
+                "",
+                [],
+                404
+            )
+        );
 
-        $handler = HandlerStack::create($mock);
-        $guzzle = new Client(['handler' => $handler]);
-        $api = new FedoraApi($guzzle);
+        $api = FedoraApi::create(self::$webserver->getHost());
 
         //304
-        $result = $api->getResource("");
+        $result = $api->getResource($test_uri1);
         $this->assertEquals(304, $result->getStatusCode());
 
         //404
-        $result = $api->getResource("");
+        $result = $api->getResource($test_uri2);
         $this->assertEquals(404, $result->getStatusCode());
     }
 }

--- a/test/GetTimemapURITest.php
+++ b/test/GetTimemapURITest.php
@@ -1,20 +1,16 @@
 <?php
 
-namespace Islandora\Chullo;
+namespace Islandora\Chullo\Test;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
+use donatj\MockWebServer\Response;
 use Islandora\Chullo\FedoraApi;
-use PHPUnit\Framework\TestCase;
 
-class GetTimemapURITest extends TestCase
+class GetTimemapURITest extends ChulloTestBase
 {
 
     /**
-     * @covers  Islandora\Chullo\FedoraApi::getTimemapURI
-     * @uses    GuzzleHttp\Client
+     * @covers  \Islandora\Chullo\FedoraApi::getTimemapURI
+     * @uses    \GuzzleHttp\Client
      */
     public function testReturnsTimemapHeaderOn200()
     {
@@ -27,18 +23,18 @@ class GetTimemapURITest extends TestCase
             'Link' => '<http://www.w3.org/ns/ldp#Container>;rel="type"',
             'Link' => '<http://localhost:8080/rest/path/to/resource/fcr:versions>;rel="timemap"',
         ];
-
-        $mock = new MockHandler(
-            [
-            new Response(200, $headers)
-            ]
+        $test_uri = self::$webserver->setResponseOfPath(
+            "/rest/path/to/resource",
+            new Response(
+                "",
+                $headers,
+                200
+            )
         );
 
-        $handler = HandlerStack::create($mock);
-        $guzzle = new Client(['handler' => $handler]);
-        $api = new FedoraApi($guzzle);
+        $api = FedoraApi::create(self::$webserver->getHost());
 
-        $timemapuri = $api->getTimemapURI("");
+        $timemapuri = $api->getTimemapURI($test_uri);
 
         $this->assertEquals("http://localhost:8080/rest/path/to/resource/fcr:versions", $timemapuri);
     }

--- a/test/ModifyResourceTest.php
+++ b/test/ModifyResourceTest.php
@@ -1,32 +1,34 @@
 <?php
 
-namespace Islandora\Chullo;
+namespace Islandora\Chullo\Test;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
+use donatj\MockWebServer\Response;
+use donatj\MockWebServer\ResponseByMethod;
 use Islandora\Chullo\FedoraApi;
-use PHPUnit\Framework\TestCase;
 
-class ModifyResourceTest extends TestCase
+class ModifyResourceTest extends ChulloTestBase
 {
 
     /**
-     * @covers  Islandora\Chullo\FedoraApi::modifyResource
-     * @uses    GuzzleHttp\Client
+     * @covers  \Islandora\Chullo\FedoraApi::modifyResource
+     * @uses    \GuzzleHttp\Client
      */
     public function testReturnsTrueOn204()
     {
-        $mock = new MockHandler([
-            new Response(204),
-        ]);
+        $test_uri = self::$webserver->setResponseOfPath(
+            "/rest/path/to/resource",
+            new ResponseByMethod([
+                ResponseByMethod::METHOD_PATCH => new Response(
+                    "",
+                    [],
+                    204
+                ),
+            ])
+        );
 
-        $handler = HandlerStack::create($mock);
-        $guzzle = new Client(['handler' => $handler]);
-        $api = new FedoraApi($guzzle);
+        $api = FedoraApi::create(self::$webserver->getHost());
 
-        $result = $api->modifyResource("");
+        $result = $api->modifyResource($test_uri);
         $this->assertEquals(204, $result->getStatusCode());
     }
 }

--- a/test/SaveGraphTest.php
+++ b/test/SaveGraphTest.php
@@ -1,32 +1,31 @@
 <?php
 
-namespace Islandora\Chullo;
+namespace Islandora\Chullo\Test;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
+use donatj\MockWebServer\Response;
+use donatj\MockWebServer\ResponseByMethod;
+use EasyRdf\Graph;
 use Islandora\Chullo\FedoraApi;
-use PHPUnit\Framework\TestCase;
 
-class SaveGraphTest extends TestCase
+class SaveGraphTest extends ChulloTestBase
 {
 
     /**
-     * @covers  Islandora\Chullo\FedoraApi::saveGraph
-     * @uses    GuzzleHttp\Client
+     * @covers  \Islandora\Chullo\FedoraApi::saveGraph
+     * @uses    \GuzzleHttp\Client
      */
     public function testReturnsTrueOn204()
     {
-        $mock = new MockHandler([
-            new Response(204),
-        ]);
+        $test_uri = self::$webserver->setResponseOfPath(
+            "/rest/path/to/resource",
+            new ResponseByMethod([
+                ResponseByMethod::METHOD_PUT => new Response("", [], 204),
+            ])
+        );
 
-        $handler = HandlerStack::create($mock);
-        $guzzle = new Client(['handler' => $handler]);
-        $api = new FedoraApi($guzzle);
+        $api = FedoraApi::create(self::$webserver->getHost());
 
-        $result = $api->saveGraph(new \EasyRdf\Graph());
+        $result = $api->saveGraph(new Graph(), $test_uri);
         $this->assertEquals(204, $result->getStatusCode());
     }
 }

--- a/test/SaveResourceTest.php
+++ b/test/SaveResourceTest.php
@@ -1,32 +1,29 @@
 <?php
 
-namespace Islandora\Chullo;
+namespace Islandora\Chullo\Test;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
+use donatj\MockWebServer\Response;
+use donatj\MockWebServer\ResponseByMethod;
 use Islandora\Chullo\FedoraApi;
-use PHPUnit\Framework\TestCase;
 
-class SaveResourceTest extends TestCase
+class SaveResourceTest extends ChulloTestBase
 {
 
     /**
-     * @covers  Islandora\Chullo\FedoraApi::saveResource
-     * @uses    GuzzleHttp\Client
+     * @covers  \Islandora\Chullo\FedoraApi::saveResource
+     * @uses    \GuzzleHttp\Client
      */
     public function testReturnsTrueOn204()
     {
-        $mock = new MockHandler([
-            new Response(204),
-        ]);
+        $test_uri = self::$webserver->setResponseOfPath(
+            "/rest/path/to/resource",
+            new ResponseByMethod([
+                ResponseByMethod::METHOD_PUT => new Response("", [], 204),
+            ])
+        );
+        $api = FedoraApi::create(self::$webserver->getHost());
 
-        $handler = HandlerStack::create($mock);
-        $guzzle = new Client(['handler' => $handler]);
-        $api = new FedoraApi($guzzle);
-
-        $result = $api->saveResource("");
+        $result = $api->saveResource($test_uri);
         $this->assertEquals(204, $result->getStatusCode());
     }
 }


### PR DESCRIPTION
# What does this Pull Request do?

Makes the `__construct` function `private`, so you must use the `create` method. We need to start storing the `base_uri` in our `FedoraApi` instance as Guzzle is [deprecating access to the getConfig() method](https://github.com/guzzle/guzzle/issues/2514). So passing in a pre-built Guzzle will no longer allow us to determine the `base_uri`.

That is why this PR is against the new 2.x branch as this will be a backwards breaking change.

* **Related GitHub Issue**: https://github.com/Islandora/documentation/issues/2220

*** **This PR is FIRST in the chain of work** ***

Dependant PRs:
* https://github.com/Islandora/Crayfish-Commons/pull/63
* https://github.com/Islandora/Crayfish/pull/174
* https://github.com/Islandora/islandora/pull/936
* https://github.com/Islandora-Devops/islandora-playbook/pull/263

# What's new?

1. Makes constructor private as described above
1. Changes in Github Actions to support Node16
1. Replaces Mockery with mock-webserver as we can't mock Guzzle response anymore so we needed a different way to test, hence mock-webserver.
1. Adds type hinting
1. Moves the tests into their own separate namespace.

* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? **yes**, if it passes in a pre-built Guzzle

# How should this be tested?

This has no real change in functionality, but there are dependant PRs that _will be_ listed above.

# Documentation Status

* Does this change existing behaviour that's currently documented? no
* Does this change require new pages or sections of documentation? no
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
