### PR TITLE
Require guzzle 6.5.8.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "require": {
         "php": ">=7.4",
-        "guzzlehttp/guzzle": "^6.5 || ^7.4",
+        "guzzlehttp/guzzle": "^6.5.8 || ^7.4",
         "easyrdf/easyrdf": "^1",
         "ml/json-ld": "^1.0.4"
     },


### PR DESCRIPTION
# What does this Pull Request do?

Bumps the depenency spec of guzzlehttp/guzzle to 6.5.8.


* **Other Relevant Links**:  https://github.com/Islandora/documentation/issues/2235

# What's new?

This ensures that the guzzlehttp/psr7 library (required by guzzlehttp/guzzle) is at least version 1.9, which will allow us (in the Islandora module, and potentially here) to use the `Header` class introduced therein, and allow us to remove deprecated code. 


# How should this be tested?

Tests should pass, being able to find a compatible suite of dependencies.

# Documentation Status
n/a

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
@jordandukart 