### PR TITLE
Stream fedora GET calls (except for Range requests)

### DIFF
--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -92,7 +92,11 @@ class FedoraApi implements IFedoraApi
         array $headers = []
     ): ResponseInterface {
         // Set headers
-        $options = ['http_errors' => false, 'headers' => $headers];
+        $options = [
+            'http_errors' => false,
+            'headers' => $headers,
+            'stream' => true,
+        ];
 
         // Send the request.
         return $this->client->request(

--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -95,7 +95,9 @@ class FedoraApi implements IFedoraApi
         $options = [
             'http_errors' => false,
             'headers' => $headers,
-            'stream' => true,
+            // Do not stream if a Range header is requested
+            // so symfony can seek to the range offset.
+            'stream' => empty($headers['Range']),
         ];
 
         // Send the request.


### PR DESCRIPTION
# What does this Pull Request do?

Streams `GET` responses from fedora

# What's new?

Downloading large files from Islandora's fedora flysystem URI scheme takes several minutes for the stream to begin transmitting the file. This is because the flysystem adapter ([which properly uses streams](https://github.com/Islandora/islandora/blob/a4c953f88a426879fa4244cee792231312315ce5/src/Flysystem/Adapter/FedoraAdapter.php#L105
)) is blocked until a full download of the file is performed from this library's calls.

# How should this be tested?

1. Upload a large (250MB+) file to fedora
2. Run

```
curl -v -o file.ext https://islandora.dev/_flysystem/fedora/path/to/file.ext
```
and notice curl hangs for several second/minutes before the stream even begins downloading the file (depending on the file size and network speed this can be minutes)
 
```
  0     0    0     0    0     0      0      0 --:--:--  0:01:54 --:--:--     0
```

 3. Apply this patch
 4. Run the same `curl` command and notice the download begins immediately
 
 ```
  25 12.3G   25 3243M    0     0  9661k      0  0:22:15  0:05:43  0:16:32 9294k
  ```
  
# Documentation Status

* Does this change existing behaviour that's currently documented? no
* Does this change require new pages or sections of documentation? no
* Who does this need to be documented for? no one

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
@Islandora/committers
