### PR TITLE
Do not stream images

### DIFF
--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -105,6 +105,7 @@ class FedoraApi implements IFedoraApi
           'ico',
           'heic',
           'avif',
+          'jp2',
         ];
 
         // Set headers

--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -92,7 +92,20 @@ class FedoraApi implements IFedoraApi
         array $headers = []
     ): ResponseInterface {
         $extension = strtolower(pathinfo($uri, PATHINFO_EXTENSION));
-        $commonImageExtensions = ['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'tiff', 'tif', 'svg', 'ico', 'heic', 'avif'];
+        $commonImageExtensions = [
+          'png',
+          'jpg',
+          'jpeg',
+          'gif',
+          'bmp',
+          'webp',
+          'tiff',
+          'tif',
+          'svg',
+          'ico',
+          'heic',
+          'avif',
+        ];
 
         // Set headers
         $options = [

--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -91,13 +91,17 @@ class FedoraApi implements IFedoraApi
         string $uri = "",
         array $headers = []
     ): ResponseInterface {
+        $extension = strtolower(pathinfo($uri, PATHINFO_EXTENSION));
+        $commonImageExtensions = ['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'tiff', 'tif', 'svg', 'ico', 'heic', 'avif'];
+
         // Set headers
         $options = [
             'http_errors' => false,
             'headers' => $headers,
             // Do not stream if a Range header is requested
             // so symfony can seek to the range offset.
-            'stream' => empty($headers['Range']),
+            // or images dues to https://bugs.php.net/bug.php?id=69706
+            'stream' => empty($headers['Range']) && !in_array($extension, $commonImageExtensions),
         ];
 
         // Send the request.


### PR DESCRIPTION
# What does this Pull Request do?

Does not stream images from fedora. When streaming images, uploading images fails due to how php/Drupal lack stream support on core image functions (e.g. https://bugs.php.net/bug.php?id=69706 )

* **Related GitHub Issue**: (link)

* **Other Relevant Links**: https://islandora.slack.com/archives/CM5PPAV28/p1748537680421139

# What's new?

Check if an image is being accessed from fedora, and if it is do not stream the response

# How should this be tested?

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the Pull Request does what is intended.
* Please be as detailed as possible.
* Good testing instructions help get your PR completed faster.

# Documentation Status

* Does this change existing behaviour that's currently documented?
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
