### PR TITLE
Revert "Stream fedora GET calls (except for Range requests)"

### DIFF
--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -92,13 +92,7 @@ class FedoraApi implements IFedoraApi
         array $headers = []
     ): ResponseInterface {
         // Set headers
-        $options = [
-            'http_errors' => false,
-            'headers' => $headers,
-            // Do not stream if a Range header is requested
-            // so symfony can seek to the range offset.
-            'stream' => empty($headers['Range']),
-        ];
+        $options = ['http_errors' => false, 'headers' => $headers];
 
         // Send the request.
         return $this->client->request(


### PR DESCRIPTION
Reverts Islandora/chullo#101, which introduced streaming responses from fedora.

I began troubleshooting an image upload error caused by streaming our response from fedora in https://github.com/Islandora/chullo/pull/102. That caused more research to resolve the issue, and I discovered the underlying issue's resolution is spread across multiple libraries, some of which are in the core php source. Given the scope of the problem I determined we should not be attempting to reap the performance benefits of streaming http requests from fedora until the programming language and libraries we rely on provide better streaming support.

The long and short of the problem is flysystem is an abstraction for a traditional filesystem. Some core php functions (e.g. [imagesize](https://www.php.net/manual/en/function.getimagesize.php)) and/or php libraries assume seekable streams (i.e. you can move a pointer back and forth for a file being read). Since our flysystem integration with fedora is over http, if we stream the fedora response that stream is not seekable since http can only be read once. This causes any function call assuming seekable streams to throw errors.

Some example issues covering the scope of the problem:

https://bugs.php.net/bug.php?id=69706
https://github.com/guzzle/psr7/issues/535
https://github.com/thephpleague/flysystem/issues/419
https://github.com/thephpleague/flysystem/issues/1579
https://www.drupal.org/project/flysystem_s3/issues/3203286

CC @rbos